### PR TITLE
Add support for backward compatibility with FST serializers

### DIFF
--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -2,15 +2,12 @@ name: License Compliance
 
 on:
   push:
-    branches: [ "*" ]
+    branches: '**'
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
   pull_request:
-    branches: [ "*" ]
-    paths:
-      - '**/pom.xml'
-      - 'pom.xml'
+    branches: '**'
   workflow_dispatch:
 
 permissions:
@@ -18,31 +15,10 @@ permissions:
   contents: write
 
 jobs:
-  check-licenses:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'zulu'
-          cache: maven
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          settings-path: ${{ github.workspace }} # location for the settings.xml file
-
-      - name: Build with Maven and check dependencies with dash
-        run: |
-          mvn --batch-mode --update-snapshots verify -P dash
-          
-      - name: Ensure DEPENDENCIES file is reflecting the current state
-        run: |
-          mvn org.eclipse.dash:license-tool-plugin:license-check -Ddash.summary=DEPENDENCIES-gen -P dash
-          diff DEPENDENCIES DEPENDENCIES-gen
-          
-      - name: upload results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          path: 'target/dash/summary'
+  check_licences:
+    uses: eclipse-ecsp/.github/.github/workflows/workflow-licences-analysis.yml@main
+    name: Analyse Licences
+    with:
+      create-review: true
+    secrets:
+      token: ${{ secrets.GITLAB_API_TOKEN }}

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -14,20 +14,20 @@ jobs:
   secret-presence:
     runs-on: ubuntu-latest
     outputs:
-      HAS_OSSRH: ${{ steps.secret-presence.outputs.HAS_OSSRH }}
+      HAS_CENTRAL_SONATYPE_SECRETS: ${{ steps.secret-presence.outputs.HAS_CENTRAL_SONATYPE_SECRETS }}
     steps:
       - name: Check whether secrets exist
         id: secret-presence
         run: |
           [ ! -z "${{ secrets.GPG_PASSPHRASE }}" ] && 
           [ ! -z "${{ secrets.GPG_PRIVATE_KEY }}" ] && 
-          [ ! -z "${{ secrets.OSSRH_USERNAME }}" ] && 
-          [ ! -z "${{ secrets.OSSRH_PASSWORD }}" ]  && 
-          echo "HAS_OSSRH=true" >> $GITHUB_OUTPUT
+          [ ! -z "${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}" ] && 
+          [ ! -z "${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}" ]  && 
+          echo "HAS_CENTRAL_SONATYPE_SECRETS=true" >> $GITHUB_OUTPUT
           exit 0
           
   publish-to-sonatype:
-    name: "Publish artifacts to OSSRH Snapshots / MavenCentral"
+    name: "Publish artifacts to Maven Central"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -35,7 +35,7 @@ jobs:
     needs: [ secret-presence ]
 
     if: |
-      needs.secret-presence.outputs.HAS_OSSRH
+      needs.secret-presence.outputs.HAS_CENTRAL_SONATYPE_SECRETS
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -58,9 +58,9 @@ jobs:
           echo "<settings xmlns='http://maven.apache.org/SETTINGS/1.0.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd'>
             <servers>
               <server>
-                <id>ossrh</id>
-                <username>${{ secrets.OSSRH_USERNAME }}</username>
-                <password>${{ secrets.OSSRH_PASSWORD }}</password>
+                <id>central</id>
+                <username>${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}</username>
+                <password>${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}</password>
               </server>
             </servers>
           </settings>" > $HOME/.m2/settings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
             <name>Hussain Badshah</name>
             <email>Hussain.Badshah@harman.com</email>
         </developer>
+        <developer>
+            <id>kaushalaroraharman</id>
+            <name>Kaushal Arora</name>
+            <email>kaushal.arora@harman.com</email>
+        </developer>
     </developers>
 
     <licenses>
@@ -83,7 +88,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.test.version>6.1.14</spring.test.version>
         <utils.version>1.1.0</utils.version>
-        <entities.version>1.1.1</entities.version>
+        <entities.version>1.1.2</entities.version>
         <maven.surefire.version>2.18.1</maven.surefire.version>
         <!--Checkstyle plugin properties -->
         <checkstyle.version>10.13.0</checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -129,17 +129,6 @@
         </java.17.options>
     </properties>
 
-    <distributionManagement>
-        <snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
-		<repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-    </distributionManagement>
-
     <pluginRepositories>
         <pluginRepository>
             <id>dash-licenses-releases</id>
@@ -483,29 +472,21 @@
 			<properties>
                 <maven.test.skip>true</maven.test.skip>
             </properties>
-			<distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-                <repository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-            </distributionManagement>
             <build>
                 <plugins>
 					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.6.13</version>
-						<extensions>true</extensions>
-						<configuration>
-							<serverId>ossrh</serverId>
-							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose>
-						</configuration>
-					</plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                            <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
+                            <skipPublishing>false</skipPublishing>
+                        </configuration>
+                    </plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
@@ -553,16 +534,6 @@
 			<properties>
                 <maven.test.skip>true</maven.test.skip>
             </properties>
-			<distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-                <repository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-            </distributionManagement>
             <build>
                 <plugins>
 					<plugin>

--- a/src/main/java/org/eclipse/ecsp/transform/Transformer.java
+++ b/src/main/java/org/eclipse/ecsp/transform/Transformer.java
@@ -95,6 +95,8 @@ public interface Transformer {
 
     /**
      * Source will determine which implementation of the transformer should be used.
+     *
+     * @return source : String
      */
     public String getSource();
 

--- a/src/test/java/org/eclipse/ecsp/transform/IngestionSerializerFstImplTest.java
+++ b/src/test/java/org/eclipse/ecsp/transform/IngestionSerializerFstImplTest.java
@@ -1,0 +1,246 @@
+/*
+ *
+ *
+ *   ******************************************************************************
+ *
+ *    Copyright (c) 2023-24 Harman International
+ *
+ *
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ *    you may not use this file except in compliance with the License.
+ *
+ *    You may obtain a copy of the License at
+ *
+ *
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *    See the License for the specific language governing permissions and
+ *
+ *    limitations under the License.
+ *
+ *
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ *
+ *    *******************************************************************************
+ *
+ *
+ */
+
+package org.eclipse.ecsp.transform;
+
+import org.eclipse.ecsp.domain.BlobDataV1_0;
+import org.eclipse.ecsp.domain.DeviceConnStatusV1_0;
+import org.eclipse.ecsp.entities.IgniteBlobEvent;
+import org.eclipse.ecsp.entities.IgniteDeviceAwareBlobEvent;
+import org.eclipse.ecsp.serializer.IngestionSerializerFstImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Base64;
+
+/**
+ * Testing IngestionSerializerFstImpl for events serialized with legacy classes and package name.
+ */
+public class IngestionSerializerFstImplTest {
+
+    /** Property to check if device aware is enabled. */
+    private static final String DEVICE_AWARE_ENABLED = "device.aware.enabled";
+    
+    /** 
+     * Reset properties before each test.
+     */
+    @Before
+    public void resetProperties() throws Exception {
+        Field propertiesField = IngestionSerializerFstImpl.class.getDeclaredField("properties");
+        propertiesField.setAccessible(true);
+        propertiesField.set(null, null);
+    }
+
+    /**
+     * Test de-serialization of DeviceConnStatusV1_0 data.
+     *
+     * <p>This test uses a serialized data string that represents
+     * an instance of DeviceConnStatusV1_0 and IgniteBlobEvent.
+     * These instances have been serialized using the legacy classes and package names.
+     */
+    @Test
+    public void testDeviceConnStatusDataDeserialization() {
+
+        IngestionSerializerFstImpl serializer = new IngestionSerializerFstImpl();
+        System.setProperty(DEVICE_AWARE_ENABLED, "false");
+        /*
+        // Commented out code for creating an instance of DeviceConnStatusV1_0 and IgniteBlobEvent
+        // using legacy classes and package names.
+        // This is for reference and can be used to generate the serialized data string.
+        com.harman.ignite.entities.IgniteBlobEvent originalEvent = new com.harman.ignite.entities.IgniteBlobEvent();
+        com.harman.ignite.domain.DeviceConnStatusV1_0 data = new com.harman.ignite.domain.DeviceConnStatusV1_0();
+        data.setServiceName("TestService1");
+        data.setConnStatus(com.harman.ignite.domain.DeviceConnStatusV1_0.ConnectionStatus.ACTIVE);
+        originalEvent.setEventId("testEvent");
+        originalEvent.setVersion(Version.V1_0);
+        originalEvent.setRequestId("Req1234");
+        originalEvent.setVehicleId("Vehicle1234");
+        originalEvent.setEventData(data);
+        
+        byte[] serializedDataB = serializer.serialize(originalEvent);
+        
+        System.out.println("Serialized data : " + new String(serializedDataB));
+        
+        String data1 = Base64.getEncoder().encodeToString(serializedDataB);
+        System.out.println("Data encoded to String: " + data1);
+        */
+
+        // Serialized data string representing an instance of DeviceConnStatusV1_0 and IgniteBlobEvent
+        // created using legacy classes and package names.
+        String serializedDataStr = "rO0AASpjb20uaGFybWFuLmlnbml0ZS5lbnRpdGllcy5JZ25pdGVCbG9iRX"
+                + "ZlbnQAAAEtY29tLmhhcm1hbi5pZ25pdGUuZG9tYWluLkRldmljZUNvbm5TdGF0dXNWMV8w+gE+Y"
+                + "29tLmhhcm1hbi5pZ25pdGUuZG9tYWluLkRldmljZUNvbm5TdGF0dXNWMV8wJENvbm5lY3Rpb25T"
+                + "dGF0dXMA//wMVGVzdFNlcnZpY2UxAPwJdGVzdEV2ZW50/AdSZXExMjM0/////AtWZWhpY2xlMTI"
+                + "zNPoBH29yZy5lY2xpcHNlLmVjc3AuZG9tYWluLlZlcnNpb24AAA==";
+        byte[] serializedData = Base64.getDecoder().decode(serializedDataStr);
+        
+        IgniteBlobEvent deserializedEvent = serializer.deserialize(serializedData);
+        
+        Assert.assertNotNull(deserializedEvent);
+        Assert.assertEquals("testEvent", deserializedEvent.getEventId());
+        Assert.assertEquals("TestService1", ((DeviceConnStatusV1_0) deserializedEvent.getEventData()).getServiceName());
+        Assert.assertEquals("ACTIVE", 
+                ((DeviceConnStatusV1_0) deserializedEvent.getEventData()).getConnStatus().getConnectionStatus());
+    }
+    
+    /**
+     * Test de-serialization of BlobEventData.
+     *
+     * <p>This test uses a serialized data string that represents
+     * an instance of BlobDataV1_0 and IgniteBlobEvent.
+     * These instances have been serialized using the legacy classes and package names.
+     */
+    @Test
+    public void testBlobEventDataDeserialization() {
+        
+        IngestionSerializerFstImpl serializer = new IngestionSerializerFstImpl();
+        System.setProperty(DEVICE_AWARE_ENABLED, "false");
+        /*
+        // Commented out code for creating an instance of DeviceConnStatusV1_0 and IgniteBlobEvent
+        // using legacy classes and package names.
+        // This is for reference and can be used to generate the serialized data string.
+        String payloadStr = "dummypayload";
+        byte[] payload = Base64.getDecoder().decode(payloadStr);
+        com.harman.ignite.entities.IgniteBlobEvent originalEvent = new com.harman.ignite.entities.IgniteBlobEvent();
+        com.harman.ignite.domain.BlobDataV1_0 data = new com.harman.ignite.domain.BlobDataV1_0();
+        data.setEventSource("Ignite");
+        data.setEncoding(com.harman.ignite.domain.AbstractBlobEventData.Encoding.JSON);
+        data.setPayload(payload);
+        originalEvent.setEventId("testEvent");
+        originalEvent.setVersion(Version.V1_0);
+        originalEvent.setRequestId("Req1234");
+        originalEvent.setVehicleId("Vehicle1234");
+        originalEvent.setEventData(data);
+        
+        byte[] serializedDataB = serializer.serialize(originalEvent);
+        
+        System.out.println("Serialized data : " + new String(serializedDataB));
+        
+        String data1 = Base64.getEncoder().encodeToString(serializedDataB);
+        System.out.println("Data encoded to String: " + data1);
+        */
+
+        // Serialized data string representing an instance of BlobDataV1_0 and IgniteBlobEvent
+        // created using legacy classes and package names.
+        String serializedDataStr = "rO0AASpjb20uaGFybWFuLmlnbml0ZS5lbnRpdGllcy5JZ25pdGVCbG9iRXZlbn"
+                + "QAAAElY29tLmhhcm1hbi5pZ25pdGUuZG9tYWluLkJsb2JEYXRhVjFfMPoBNm9yZy5lY2xpcHNlLmVjc"
+                + "3AuZG9tYWluLkFic3RyYWN0QmxvYkV2ZW50RGF0YSRFbmNvZGluZwH//AZJZ25pdGX7JAl26abKlrKW"
+                + "hp0A/Al0ZXN0RXZlbnT8B1JlcTEyMzT////8C1ZlaGljbGUxMjM0+gEfb3JnLmVjbGlwc2UuZWNzcC5"
+                + "kb21haW4uVmVyc2lvbgAA";
+        byte[] serializedData = Base64.getDecoder().decode(serializedDataStr);
+        
+        IgniteBlobEvent deserializedEvent = serializer.deserialize(serializedData);
+
+        Assert.assertNotNull(deserializedEvent);
+        Assert.assertEquals("testEvent", deserializedEvent.getEventId());
+        Assert.assertEquals("Ignite", ((BlobDataV1_0) deserializedEvent.getEventData()).getEventSource());
+        Assert.assertEquals("json", ((BlobDataV1_0) deserializedEvent.getEventData()).getEncoding().getEncode());
+        
+        byte[] payloadReceived = ((BlobDataV1_0) deserializedEvent.getEventData()).getPayload();
+        String payloadStr = Base64.getEncoder().encodeToString(payloadReceived);
+        Assert.assertEquals("dummypayload", payloadStr);
+    }
+    
+    /**
+     * Test de-serialization of DeviceAwareBlobEventData.
+     *
+     * <p>his test uses a serialized data string that represents
+     * an instance of IgniteDeviceAwareBlobEvent and BlobDataV1_0.
+     * These instances have been serialized using the legacy classes and package names.
+     */
+    @Test
+    public void testDeviceAwareBlobEventDataDeserialization() {
+
+        IngestionSerializerFstImpl serializer = new IngestionSerializerFstImpl();
+        System.setProperty(DEVICE_AWARE_ENABLED, "true");
+        
+        /*
+        // Commented out code for creating an instance of DeviceConnStatusV1_0 and IgniteBlobEvent
+        // using legacy classes and package names.
+        // This is for reference and can be used to generate the serialized data string.
+        String payloadStr = "dummypayload";
+        byte[] payload = Base64.getDecoder().decode(payloadStr);
+        com.harman.ignite.entities.IgniteBlobEvent originalEvent = 
+            new com.harman.ignite.entities.IgniteDeviceAwareBlobEvent("ECU1234", "MQTT/Topic/1234");
+        com.harman.ignite.domain.BlobDataV1_0 data = new com.harman.ignite.domain.BlobDataV1_0();
+        data.setEventSource("Ignite");
+        data.setEncoding(com.harman.ignite.domain.AbstractBlobEventData.Encoding.JSON);
+        data.setPayload(payload);
+        originalEvent.setEventId("testEvent");
+        originalEvent.setVersion(Version.V1_0);
+        originalEvent.setRequestId("Req1234");
+        originalEvent.setVehicleId("Vehicle1234");
+        originalEvent.setEventData(data);
+        
+        byte[] serializedDataB = serializer.serialize(originalEvent);
+        
+        System.out.println("Serialized data : " + new String(serializedDataB));
+        
+        String data1 = Base64.getEncoder().encodeToString(serializedDataB);
+        System.out.println("Data encoded to String: " + data1);
+        */
+
+        // Serialized data string representing an instance of IgniteDeviceAwareBlobEvent and BlobDataV1_0
+        // created using legacy classes and package names.
+        String serializedDataStr = "rO0AATVjb20uaGFybWFuLmlnbml0ZS5lbnRpdGllcy5JZ25pdGVEZXZpY2VBd2FyZUJ"
+                + "sb2JFdmVudAAAASVjb20uaGFybWFuLmlnbml0ZS5kb21haW4uQmxvYkRhdGFWMV8w+gE3Y29tLmhhcm1hbi5p"
+                + "Z25pdGUuZG9tYWluLkFic3RyYWN0QmxvYkV2ZW50RGF0YSRFbmNvZGluZwH//AZJZ25pdGX7JAl26abKlrKWh"
+                + "p0A/AdFQ1UxMjM0/Al0ZXN0RXZlbnT8D01RVFQvVG9waWMvMTIzNPwHUmVxMTIzNP////wLVmVoaWNsZTEyMzT"
+                + "6AR9vcmcuZWNsaXBzZS5lY3NwLmRvbWFpbi5WZXJzaW9uAAA=";
+        byte[] serializedData = Base64.getDecoder().decode(serializedDataStr);
+        
+        IgniteDeviceAwareBlobEvent deserializedEvent = (IgniteDeviceAwareBlobEvent) serializer
+                .deserialize(serializedData);
+
+        Assert.assertNotNull(deserializedEvent);
+        Assert.assertTrue(deserializedEvent instanceof org.eclipse.ecsp.entities.IgniteDeviceAwareBlobEvent);
+        Assert.assertEquals("testEvent", deserializedEvent.getEventId());
+        Assert.assertEquals("Ignite", ((BlobDataV1_0) deserializedEvent.getEventData()).getEventSource());
+        Assert.assertEquals("json", ((BlobDataV1_0) deserializedEvent.getEventData()).getEncoding().getEncode());
+        
+        Assert.assertEquals("ECU1234", deserializedEvent.getEcuType());
+        Assert.assertEquals("MQTT/Topic/1234", deserializedEvent.getMqttTopic());
+        
+        byte[] payloadReceived = ((BlobDataV1_0) deserializedEvent.getEventData()).getPayload();
+        String payloadStrReceived = Base64.getEncoder().encodeToString(payloadReceived);
+        Assert.assertEquals("dummypayload", payloadStrReceived);
+    }
+}


### PR DESCRIPTION
RESOLVES #9 

This PR adds support for backward compatibility with FST serializers using legacy class name and packages. It introduces a custom deserialiazer for mapping fields from the legacy classes, to the new classes for events and event data received on Kafka topic. 

This is required since some of the components are still using the older legacy classes, causing Kafka events to be serialized by FST with the legacy package name.

Once all the services have been migrated to newer classes, this custom deserializer can be removed.